### PR TITLE
fix: App crashes when touching notification

### DIFF
--- a/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddFencesIntentService.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddFencesIntentService.java
@@ -88,8 +88,8 @@ public class AddFencesIntentService extends IntentService
             AwarenessFence location = LocationFence.in(
                     entry.getValue().latitude,
                     entry.getValue().longitude,
-                    Constants.GEOFENCE_MALL_RADIUS_IN_METERS,
-                    Constants.GEOFENCE_MALL_DWELL_IN_MILLISECONDS);
+                    Constants.FENCE_MALL_RADIUS_IN_METERS,
+                    Constants.FENCE_MALL_DWELL_IN_MILLISECONDS);
             builder.addFence(entry.getKey(), location, mPendingIntent).build();
         }
         mMallFenceUpdateRequest = builder.build();
@@ -97,8 +97,8 @@ public class AddFencesIntentService extends IntentService
         if (!mGoogleApiClient.isConnected()) {
             mGoogleApiClient.connect();
         } else {
-            SharedPreferences preferences = getSharedPreferences(Constants.MALL_GEOFENCES, 0);
-            boolean mallGeofencesAdded = preferences.getBoolean(Constants.MALL_GEOFENCES_ADDED, false);
+            SharedPreferences preferences = getSharedPreferences(Constants.MALL_FENCES, 0);
+            boolean mallGeofencesAdded = preferences.getBoolean(Constants.MALL_FENCES_ADDED, false);
             if (!mallGeofencesAdded && mMallFenceUpdateRequest != null) {
                 addFences("mall");
             }
@@ -115,8 +115,8 @@ public class AddFencesIntentService extends IntentService
             AwarenessFence location = LocationFence.in(
                     entry.getValue().latitude,
                     entry.getValue().longitude,
-                    Constants.GEOFENCE_LANDMARK_RADIUS_IN_METERS,
-                    Constants.GEOFENCE_LANDMARK_DWELL_IN_MILLISECONDS);
+                    Constants.FENCE_LANDMARK_RADIUS_IN_METERS,
+                    Constants.FENCE_LANDMARK_DWELL_IN_MILLISECONDS);
             builder.addFence(entry.getKey(), location, mPendingIntent).build();
         }
         mLandmarkFenceUpdateRequest = builder.build();
@@ -145,9 +145,9 @@ public class AddFencesIntentService extends IntentService
             }
 
             // Mark mall fences as added.
-            SharedPreferences preferences = getSharedPreferences(Constants.MALL_GEOFENCES, 0);
+            SharedPreferences preferences = getSharedPreferences(Constants.MALL_FENCES, 0);
             SharedPreferences.Editor editor = preferences.edit();
-            editor.putBoolean(Constants.MALL_GEOFENCES_ADDED, true);
+            editor.putBoolean(Constants.MALL_FENCES_ADDED, true);
             editor.apply();
         } else if (type.contentEquals("landmark")) {
             try {
@@ -163,8 +163,8 @@ public class AddFencesIntentService extends IntentService
 
     @Override
     public void onConnected(@Nullable Bundle bundle) {
-        SharedPreferences preferences = getSharedPreferences(Constants.MALL_GEOFENCES, 0);
-        boolean mallGeofencesAdded = preferences.getBoolean(Constants.MALL_GEOFENCES_ADDED, false);
+        SharedPreferences preferences = getSharedPreferences(Constants.MALL_FENCES, 0);
+        boolean mallGeofencesAdded = preferences.getBoolean(Constants.MALL_FENCES_ADDED, false);
         if (!mallGeofencesAdded && mMallFenceUpdateRequest != null) {
             addFences("mall");
         }

--- a/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddGeofencesIntentService.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddGeofencesIntentService.java
@@ -98,7 +98,7 @@
 //     * parameters.
 //     */
 //    private void handleAddMallGeofences(String param1, String param2) {
-////        populateGeofenceList(Constants.GEOFENCE_MALL_RADIUS_IN_METERS);
+////        populateGeofenceList(Constants.FENCE_MALL_RADIUS_IN_METERS);
 //
 //        for (Map.Entry<String, LatLng> entry : Constants.TEST_MALLS.entrySet()) {
 //            mGeofences.add(new Geofence.Builder()
@@ -106,9 +106,9 @@
 //                    .setCircularRegion(
 //                            entry.getValue().latitude,
 //                            entry.getValue().longitude,
-//                            Constants.GEOFENCE_MALL_RADIUS_IN_METERS
+//                            Constants.FENCE_MALL_RADIUS_IN_METERS
 //                    )
-//                    .setExpirationDuration(Constants.GEOFENCE_EXPIRATION_IN_MILLISECONDS)
+//                    .setExpirationDuration(Constants.FENCE_EXPIRATION_IN_MILLISECONDS)
 //                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 //                            Geofence.GEOFENCE_TRANSITION_EXIT)
 //                    .build());
@@ -126,7 +126,7 @@
 //     * parameters.
 //     */
 //    private void handleAddLandmarkGeofences(String param1, String param2) {
-////        populateGeofenceList(Constants.GEOFENCE_LANDMARK_RADIUS_IN_METERS);
+////        populateGeofenceList(Constants.FENCE_LANDMARK_RADIUS_IN_METERS);
 //
 //        for (Map.Entry<String, LatLng> entry : Constants.TEST_LANDMARKS.entrySet()) {
 //            mGeofences.add(new Geofence.Builder()
@@ -134,9 +134,9 @@
 //                    .setCircularRegion(
 //                            entry.getValue().latitude,
 //                            entry.getValue().longitude,
-//                            Constants.GEOFENCE_LANDMARK_RADIUS_IN_METERS
+//                            Constants.FENCE_LANDMARK_RADIUS_IN_METERS
 //                    )
-//                    .setExpirationDuration(Constants.GEOFENCE_EXPIRATION_IN_MILLISECONDS)
+//                    .setExpirationDuration(Constants.FENCE_EXPIRATION_IN_MILLISECONDS)
 //                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 //                            Geofence.GEOFENCE_TRANSITION_EXIT)
 //                    .build());
@@ -168,9 +168,9 @@
 //        }
 //
 //        // Mark geofences as added.
-//        SharedPreferences preferences = getSharedPreferences(Constants.MALL_GEOFENCES, 0);
+//        SharedPreferences preferences = getSharedPreferences(Constants.MALL_FENCES, 0);
 //        SharedPreferences.Editor editor = preferences.edit();
-//        editor.putBoolean(Constants.MALL_GEOFENCES_ADDED, true);
+//        editor.putBoolean(Constants.MALL_FENCES_ADDED, true);
 //        editor.apply();
 //    }
 //

--- a/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddGeofencesIntentServiceOLD.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddGeofencesIntentServiceOLD.java
@@ -198,7 +198,7 @@
 //                            entry.getValue().longitude,
 //                            Constants.GEOFENCE_RADIUS_IN_METERS
 //                    )
-//                    .setExpirationDuration(Constants.GEOFENCE_EXPIRATION_IN_MILLISECONDS)
+//                    .setExpirationDuration(Constants.FENCE_EXPIRATION_IN_MILLISECONDS)
 //                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 //                            Geofence.GEOFENCE_TRANSITION_EXIT)
 //                    .build());

--- a/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddLandmarkGeofencesIntentService.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddLandmarkGeofencesIntentService.java
@@ -61,9 +61,9 @@
 //                    .setCircularRegion(
 //                            entry.getValue().latitude,
 //                            entry.getValue().longitude,
-//                            Constants.GEOFENCE_LANDMARK_RADIUS_IN_METERS
+//                            Constants.FENCE_LANDMARK_RADIUS_IN_METERS
 //                    )
-//                    .setExpirationDuration(Constants.GEOFENCE_EXPIRATION_IN_MILLISECONDS)
+//                    .setExpirationDuration(Constants.FENCE_EXPIRATION_IN_MILLISECONDS)
 //                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 //                            Geofence.GEOFENCE_TRANSITION_EXIT)
 //                    .build());
@@ -93,9 +93,9 @@
 //        }
 //
 //        // Mark geofences as added.
-//        SharedPreferences preferences = getSharedPreferences(Constants.MALL_GEOFENCES, 0);
+//        SharedPreferences preferences = getSharedPreferences(Constants.MALL_FENCES, 0);
 //        SharedPreferences.Editor editor = preferences.edit();
-//        editor.putBoolean(Constants.MALL_GEOFENCES_ADDED, true);
+//        editor.putBoolean(Constants.MALL_FENCES_ADDED, true);
 //        editor.apply();
 //    }
 //

--- a/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddMallGeofencesIntentService.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/AddMallGeofencesIntentService.java
@@ -62,9 +62,9 @@
 //                    .setCircularRegion(
 //                            entry.getValue().latitude,
 //                            entry.getValue().longitude,
-//                            Constants.GEOFENCE_MALL_RADIUS_IN_METERS
+//                            Constants.FENCE_MALL_RADIUS_IN_METERS
 //                    )
-//                    .setExpirationDuration(Constants.GEOFENCE_EXPIRATION_IN_MILLISECONDS)
+//                    .setExpirationDuration(Constants.FENCE_EXPIRATION_IN_MILLISECONDS)
 //                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 //                            Geofence.GEOFENCE_TRANSITION_EXIT)
 //                    .build());
@@ -94,9 +94,9 @@
 //        }
 //
 //        // Mark geofences as added.
-//        SharedPreferences preferences = getSharedPreferences(Constants.MALL_GEOFENCES, 0);
+//        SharedPreferences preferences = getSharedPreferences(Constants.MALL_FENCES, 0);
 //        SharedPreferences.Editor editor = preferences.edit();
-//        editor.putBoolean(Constants.MALL_GEOFENCES_ADDED, true);
+//        editor.putBoolean(Constants.MALL_FENCES_ADDED, true);
 //        editor.apply();
 //    }
 //

--- a/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/TrackLocationActivity.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/trackLocation/TrackLocationActivity.java
@@ -129,7 +129,7 @@
 //                            entry.getValue().longitude,
 //                            Constants.GEOFENCE_RADIUS_IN_METERS
 //                    )
-//                    .setExpirationDuration(Constants.GEOFENCE_EXPIRATION_IN_MILLISECONDS)
+//                    .setExpirationDuration(Constants.FENCE_EXPIRATION_IN_MILLISECONDS)
 //                    .setTransitionTypes(Geofence.GEOFENCE_TRANSITION_ENTER |
 //                            Geofence.GEOFENCE_TRANSITION_EXIT)
 //                    .build());

--- a/app/src/main/java/com/example/triibe/triibeuserapp/util/Constants.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/util/Constants.java
@@ -10,26 +10,19 @@ import java.util.HashMap;
 public final class Constants {
 
     public static final int NUM_QUALIFYING_QUESTIONS = 2;
-    public static final int FOREGROUND_SERVICE = 5;
     public static final int MY_PERMISSIONS_REQUEST_ACCESS_FINE_LOCATION = 1;
+    public static final float FENCE_MALL_RADIUS_IN_METERS = 500;
+    public static final long FENCE_MALL_DWELL_IN_MILLISECONDS = 1000;
+    public static final long FENCE_LANDMARK_DWELL_IN_MILLISECONDS = 1000;
+    public static final float FENCE_LANDMARK_RADIUS_IN_METERS = 10;
+    public static final long FENCE_EXPIRATION_IN_HOURS = 12;
+    public static final long FENCE_EXPIRATION_IN_MILLISECONDS = FENCE_EXPIRATION_IN_HOURS * 60 * 60 * 1000;
+    public static final String MALL_FENCES = "mallGeofences";
+    public static final String MALL_FENCES_ADDED = "mallGeofencesAdded";
+    public static final int APP_SERVICE_RUNNING_ID = 13;
     public static final String ACTIVITY_EXTRA = "activityResult";
     public static final String BROADCAST_ACTION = "activityRecognition";
-    public static final float GEOFENCE_MALL_RADIUS_IN_METERS = 1000;
-    public static final long GEOFENCE_MALL_DWELL_IN_MILLISECONDS = 5000;
-    public static final long GEOFENCE_LANDMARK_DWELL_IN_MILLISECONDS = 1000;
-    public static final float GEOFENCE_LANDMARK_RADIUS_IN_METERS = 20;
-    public static final long GEOFENCE_EXPIRATION_IN_HOURS = 12;
-    public static final long GEOFENCE_EXPIRATION_IN_MILLISECONDS =
-            GEOFENCE_EXPIRATION_IN_HOURS * 60 * 60 * 1000;
-    public static final String MALL_GEOFENCES = "mallGeofences";
-    public static final String MALL_GEOFENCES_ADDED = "mallGeofencesAdded";
-    public static final int APP_SERVICE_RUNNING_ID = 13;
-    public static final String GEOFENCE_TYPE = "geofenceType";
-    public static final String GEOFENCE_TYPE_MALL = "geofenceTypeMall";
-    public static final String GEOFENCE_TYPE_LANDMARK = "geofenceTypeLandmark";
 
-    private Constants() {
-    }
 
     public static final HashMap<String, LatLng> WESTFIELD_MALLS = new HashMap<>();
     static {

--- a/app/src/main/java/com/example/triibe/triibeuserapp/util/RunAppWhenAtMallService.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/util/RunAppWhenAtMallService.java
@@ -80,7 +80,7 @@ public class RunAppWhenAtMallService extends Service {
                         .setContentTitle("At mall")
                         .setContentText("Tracking data")
                         .addAction(R.drawable.ic_stop_black_24dp, "Stop", mStopTrackingPendingIntent);
-        Intent resultIntent = new Intent(this, ViewSurveysActivity.class);
+        Intent resultIntent = new Intent(this, AuthUiActivity.class);
         TaskStackBuilder stackBuilder = TaskStackBuilder.create(this);
         stackBuilder.addParentStack(ViewSurveysActivity.class);
         stackBuilder.addNextIntent(resultIntent);

--- a/app/src/main/java/com/example/triibe/triibeuserapp/view_surveys/ViewSurveysActivity.java
+++ b/app/src/main/java/com/example/triibe/triibeuserapp/view_surveys/ViewSurveysActivity.java
@@ -124,8 +124,8 @@ public class ViewSurveysActivity extends AppCompatActivity implements ViewSurvey
 //        startService(mServiceIntent);
 
         // Add mall geofences if not already added (will also be added automatically on boot)
-        SharedPreferences preferences = getSharedPreferences(Constants.MALL_GEOFENCES, 0);
-        boolean mallGeofencesAdded = preferences.getBoolean(Constants.MALL_GEOFENCES_ADDED, false);
+        SharedPreferences preferences = getSharedPreferences(Constants.MALL_FENCES, 0);
+        boolean mallGeofencesAdded = preferences.getBoolean(Constants.MALL_FENCES_ADDED, false);
         if (!mallGeofencesAdded) {
             if (EasyPermissions.hasPermissions(this, perms)) {
                 // Have permission


### PR DESCRIPTION
When the app is started from entering a fence the app is started via the
service. In this case the user hasn't necessarily authenticated with the
app. Start with authUiActivity instead of viewSurveys.
